### PR TITLE
Restore Environment

### DIFF
--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -1,2 +1,3 @@
 export * from "./exportSolution";
 export * from "./whoAmI";
+export * from "./restoreEnvironment";

--- a/src/actions/restoreEnvironment.ts
+++ b/src/actions/restoreEnvironment.ts
@@ -1,0 +1,31 @@
+import { authenticateAdmin } from "../pac/auth/authenticate";
+import createPacRunner from "../pac/createPacRunner";
+import { RunnerParameters } from "../Parameters";
+import { AuthCredentials } from "../pac/auth/authParameters";
+
+export interface RestoreEnvironmentParameters {
+  credentials: AuthCredentials;
+  backupDateTime: string;
+  sourceEnvironmentUrl?: string;
+  sourceEnvironmentId?: string;
+  targetEnvironmentUrl?: string;
+  targetEnvironmentId?: string;
+  targetEnvironmentName?: string;
+  async?: boolean;
+}
+
+export async function restoreEnvironment(parameters: RestoreEnvironmentParameters, runnerParameters: RunnerParameters): Promise<void> {
+  const pac = createPacRunner(runnerParameters);
+  await authenticateAdmin(pac, parameters.credentials);
+
+  /** Caller needs to validate at the client level if backupDateTime is of proper format and if both environment id and url are passed. */
+  const pacArgs = ["admin", "restore", "--selected-backup", parameters.backupDateTime];
+  if (parameters.sourceEnvironmentUrl) { pacArgs.push("--source-url", parameters.sourceEnvironmentUrl); }
+  if (parameters.sourceEnvironmentId) { pacArgs.push("--source-id", parameters.sourceEnvironmentId); }
+  if (parameters.targetEnvironmentUrl) { pacArgs.push("--target-url", parameters.targetEnvironmentUrl); }
+  if (parameters.targetEnvironmentId) { pacArgs.push("--target-id", parameters.targetEnvironmentId); }
+  if (parameters.targetEnvironmentName) { pacArgs.push("--name", parameters.targetEnvironmentName); }
+  if (parameters.async) { pacArgs.push("--async"); }
+
+  await pac(...pacArgs);
+}


### PR DESCRIPTION
Added Restore Environment Action with optional parameters -> Making call to PAC with required and optional parameters.

**PAC command (version 1.7.2):**
PS C:\Users\vyelleswarap\powerplatform-cli-wrapper2> pac admin restore
Microsoft PowerPlatform CLI
Version: 1.7.2+gd1a5b9b

Error: A required argument --selected-backup is missing.

**Usage: pac admin restore [--source-url] [--target-url] [--source-id] [--target-id] --selected-backup [--name] [--async]**

  **--source-url**                Environment URL of source environment required for restore. (alias: -su)
  **--target-url**                Environment URL of target environment required for restore. This would default to source URL if not provided. (alias: -tu)
  **--source-id**                 Environment Id of source environment required for restore. (alias: -si)
  **--target-id**                 Environment Id of target environment required for restore. This would default to source Id if not provided. (alias: -ti)
  **--selected-backup**           DateTime of the backup in 'mm/dd/yyyy hh:mm' format OR string 'latest'. (alias: -sb)
  **--name**                      Optional name of the restored environment. (alias: -n)
  **--async**                     Optional boolean argument to run pac verbs asynchronously, defaults to false. (alias: -a)

TBD - Unit test