### PR TITLE
improved publishing automation

### DIFF
--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -3,7 +3,8 @@ name: Publish Npm Package
 on:
   push:
     tags:
-      - "v*"
+      # trigger publish builds via npm run trigger-pkg-release (requires push tags permissions to origin)
+      - "rc*"
 
 jobs:
   build_publish:
@@ -22,7 +23,8 @@ jobs:
 
       - name: Build
         run: |
-          npm i
+          npm ci
+          npm run set-version
           npm run dist
         env:
           AZ_DevOps_Read_PAT: ${{ secrets.AZ_DevOps_Read_PAT }}

--- a/.release-it.yaml
+++ b/.release-it.yaml
@@ -8,7 +8,7 @@ git:
   commit: false
   push: true
   requireBranch: main
-  requireCommits: true
+  requireCommits: false
   requireCleanWorkingDir: true
   requireUpstream: true
   tag: true
@@ -25,6 +25,5 @@ npm:
 
 # https://github.com/release-it/release-it/blob/master/docs/github-releases.md
 github:
-  draft: false
+  draft: true
   release: false
-

--- a/.releaseIt-createRC.yaml
+++ b/.releaseIt-createRC.yaml
@@ -1,0 +1,25 @@
+# https://github.com/release-it/release-it/blob/master/config/release-it.json
+
+hooks: {}
+
+# https://github.com/release-it/release-it/blob/master/docs/git.md
+git:
+  addUntrackedFiles: false
+  commit: false
+  push: true
+  requireBranch: main
+  requireCommits: false
+  requireCleanWorkingDir: true
+  requireUpstream: true
+  tag: true
+  tagArgs: [ '--force' ]
+  tagAnnotation: |
+    build ${version}:
+    ${changelog}
+  tagName: 'rc${version}'
+
+#https://github.com/release-it/release-it/blob/master/docs/npm.md
+npm: false
+
+# https://github.com/release-it/release-it/blob/master/docs/github-releases.md
+github: false

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test": "node node_modules/gulp/bin/gulp.js test",
     "ci": "node node_modules/gulp/bin/gulp.js ci",
     "dist": "node node_modules/gulp/bin/gulp.js dist && git add -f -- ./dist",
-    "trigger-pkg-release": "node node_modules/release-it/bin/release-it --increment patch --ci -VV"
+    "trigger-pkg-release": "node node_modules/release-it/bin/release-it --increment patch --ci -VV --config ./.releaseIt-createRC.yaml",
+    "set-version": "node node_modules/release-it/bin/release-it --increment patch --ci -VV"
   },
   "author": "PowerApps-ISV-Tools",
   "license": "MIT",


### PR DESCRIPTION
this is now a 2 stage process:
- from a local repo of a user who has push to origin permissions:
    > ```npm run trigger-pkg-release```
  using the release-it tool, this will calculate and set a new git tag rc* e.g. ```rc0.1.19``` and it then pushes the tag to origin
- the pushed tag then triggers the publish.yaml workflow. It will then again use release-it to calculate the actual version tag, v* (e.g. ```v0.1.19``` and then build and publish the package 