### PR TITLE
Empty string bug in GH actions

### DIFF
--- a/src/host/InputValidator.ts
+++ b/src/host/InputValidator.ts
@@ -15,6 +15,9 @@ export class InputValidator {
     if (val === undefined && params.defaultValue !== undefined) {
       return params.defaultValue.toString();
     }
+    else if (val == '') {
+      return undefined;
+    }
     return val;
   }
 

--- a/test/host/inputValidator.test.ts
+++ b/test/host/inputValidator.test.ts
@@ -18,6 +18,14 @@ describe("input validator test", () => {
     name: hostName,
     getInput: () => inputValue,
   }
+  const mockHostReturnEmpty : IHostAbstractions = {
+    name: hostName,
+    getInput: () => "",
+  }
+  const hostParameterEntryNoDefault : HostParameterEntry = {
+    name: hostName,
+    required: false,
+  };
   const hostParameterEntryRequired : HostParameterEntry = {
     name: hostName,
     required: true,
@@ -65,6 +73,12 @@ describe("input validator test", () => {
     validator = new InputValidator(mockHostReturnUndefined);
     validator.pushInput(pacArgs, property, hostParameterEntryOptional);
     assert.deepEqual(pacArgs, [property, defaultValue]);
+  });
+
+  it("empty string", async () => {
+    validator = new InputValidator(mockHostReturnEmpty);
+    validator.pushInput(pacArgs, property, hostParameterEntryNoDefault);
+    assert.deepEqual(pacArgs, []);
   });
 
   it("do not add optional to pac args", async () => {


### PR DESCRIPTION
Bug 2506082: Github actions core getInput returns an empty string when env var not set