### PR TITLE
Add set online version solution

### DIFF
--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -21,3 +21,4 @@ export * from "./uploadPaportal";
 export * from "./downloadPaportal";
 export * from "./cloneSolution";
 export * from "./updateVersionSolution";
+export * from "./onlineVersionSolution";

--- a/src/actions/onlineVersionSolution.ts
+++ b/src/actions/onlineVersionSolution.ts
@@ -1,0 +1,39 @@
+import { HostParameterEntry, IHostAbstractions } from "../host/IHostAbstractions";
+import { InputValidator } from "../host/InputValidator";
+import { authenticateEnvironment, clearAuthentication } from "../pac/auth/authenticate";
+import createPacRunner from "../pac/createPacRunner";
+import { RunnerParameters } from "../Parameters";
+import { AuthCredentials } from "../pac/auth/authParameters";
+
+export interface OnlineVersionSolutionParameters {
+  credentials: AuthCredentials;
+  environmentUrl: string;
+  name: HostParameterEntry;
+  version: HostParameterEntry;
+}
+
+export async function onlineVersionSolution(parameters: OnlineVersionSolutionParameters, runnerParameters: RunnerParameters, host: IHostAbstractions): Promise<void> {
+  const logger = runnerParameters.logger;
+  const pac = createPacRunner(runnerParameters);
+
+  try {
+    const authenticateResult = await authenticateEnvironment(pac, parameters.credentials, parameters.environmentUrl);
+    logger.log("The Authentication Result: " + authenticateResult);
+
+    const pacArgs = ["solution", "online-version"];
+    const validator = new InputValidator(host);
+
+    validator.pushInput(pacArgs, "--solution-name", parameters.name);
+    validator.pushInput(pacArgs, "--solution-version", parameters.version);
+
+    logger.log("Calling pac cli inputs: " + pacArgs.join(" "));
+    const pacResult = await pac(...pacArgs);
+    logger.log("OnlineVersionSolution Action Result: " + pacResult);
+  } catch (error) {
+    logger.error(`failed: ${error.message}`);
+    throw error;
+  } finally {
+    const clearAuthResult = await clearAuthentication(pac);
+    logger.log("The Clear Authentication Result: " + clearAuthResult);
+  }
+}

--- a/test/actions/onlineVersionSolution.test.ts
+++ b/test/actions/onlineVersionSolution.test.ts
@@ -1,0 +1,73 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import rewiremock from "../rewiremock";
+import * as sinonChai from "sinon-chai";
+import * as chaiAsPromised from "chai-as-promised";
+import { should, use } from "chai";
+import { restore, stub } from "sinon";
+import { ClientCredentials, RunnerParameters } from "../../src";
+import { createDefaultMockRunnerParameters, createMockClientCredentials, mockEnvironmentUrl } from "./mock/mockData";
+import { OnlineVersionSolutionParameters } from "src/actions/onlineVersionSolution";
+import { IHostAbstractions } from "../../src/host/IHostAbstractions";
+import Sinon = require("sinon");
+should();
+use(sinonChai);
+use(chaiAsPromised);
+
+describe("action: set online version solution", () => {
+  let pacStub: Sinon.SinonStub<any[],any>;
+  let authenticateEnvironmentStub: Sinon.SinonStub<any[],any>;
+  let clearAuthenticationStub: Sinon.SinonStub<any[], any>;
+  const mockHost : IHostAbstractions = {
+    name: "host",
+    getInput: () => "test",
+  }
+  const name = "test";
+  const version = "1.0";
+  const mockClientCredentials: ClientCredentials = createMockClientCredentials();
+  const envUrl: string = mockEnvironmentUrl;
+  let onlineVersionSolutionParameters: OnlineVersionSolutionParameters;
+
+  beforeEach(() => {
+    pacStub = stub();
+    authenticateEnvironmentStub = stub();
+    clearAuthenticationStub = stub();
+    onlineVersionSolutionParameters = createOnlineVersionSolutionParameters();
+  })
+  afterEach(() => restore())
+
+  async function runActionWithMocks(onlineVersionSolutionParameters: OnlineVersionSolutionParameters) {
+    const runnerParameters: RunnerParameters = createDefaultMockRunnerParameters();
+    const mockedActionModule = await rewiremock.around(() => import("../../src/actions/onlineVersionSolution"),
+      (mock) => {
+        mock(() => import("../../src/pac/createPacRunner")).withDefault(() => pacStub);
+        mock(() => import("../../src/pac/auth/authenticate")).with(
+          {
+            authenticateEnvironment: authenticateEnvironmentStub,
+            clearAuthentication: clearAuthenticationStub
+          });
+      });
+    const stubFnc = Sinon.stub(mockHost, "getInput");
+    stubFnc.onCall(0).returns(name);
+    stubFnc.onCall(1).returns(version);
+
+    authenticateEnvironmentStub.returns("Authentication successfully created.");
+    clearAuthenticationStub.returns("Authentication profiles and token cache removed");
+    pacStub.returns("");
+    await mockedActionModule.onlineVersionSolution(onlineVersionSolutionParameters, runnerParameters, mockHost);
+  }
+
+  const createOnlineVersionSolutionParameters = (): OnlineVersionSolutionParameters => ({
+    credentials: mockClientCredentials,
+    environmentUrl: envUrl,
+    name: { name: 'SolutionName', required: true },
+    version: { name: 'Version', required: true },
+  });
+
+  it("with required params, calls pac runner with correct args", async () => {
+    await runActionWithMocks(onlineVersionSolutionParameters);
+
+    authenticateEnvironmentStub.should.have.been.calledOnceWith(pacStub, mockClientCredentials, envUrl);
+    pacStub.should.have.been.calledOnceWith("solution", "online-version", "--solution-name", name, "--solution-version", version);
+    clearAuthenticationStub.should.have.been.calledOnceWith(pacStub);
+  });
+});


### PR DESCRIPTION
Microsoft PowerPlatform CLI
Version: 1.10.4+gf23be2f

Help:
Sets version for solution loaded in Dataverse environment.

Commands:
Usage: pac solution online-version --solution-name --solution-version

  --solution-name             Name of the solution (alias: -sn)
  --solution-version          Specify the solution version number. (alias: -sv)