### PR TITLE
assign-user feature initial addition

### DIFF
--- a/src/actions/assignUser.ts
+++ b/src/actions/assignUser.ts
@@ -1,0 +1,41 @@
+import { HostParameterEntry, IHostAbstractions } from "../host/IHostAbstractions";
+import { InputValidator } from "../host/InputValidator";
+import { authenticateAdmin, clearAuthentication } from "../pac/auth/authenticate";
+import createPacRunner from "../pac/createPacRunner";
+import { RunnerParameters } from "../Parameters";
+import { AuthCredentials } from "../pac/auth/authParameters";
+
+export interface AssignUserParameters {
+  credentials: AuthCredentials;
+  environment: HostParameterEntry;
+  objectId: HostParameterEntry;
+  role: HostParameterEntry;
+}
+
+export async function assignUser(parameters: AssignUserParameters, runnerParameters: RunnerParameters, host: IHostAbstractions) {
+  const logger = runnerParameters.logger;
+  const pac = createPacRunner(runnerParameters);
+
+  const pacArgs = ["admin", "assign-user"];
+  const validator = new InputValidator(host);
+
+  try {
+    const authenticateResult = await authenticateAdmin(pac, parameters.credentials);
+    logger.log("The Authentication Result: " + authenticateResult);
+
+    validator.pushInput(pacArgs, "--environment", parameters.environment);
+    validator.pushInput(pacArgs, "--object-id", parameters.objectId);
+    validator.pushInput(pacArgs, "--role", parameters.role);
+
+    logger.log("Calling pac cli inputs: " + pacArgs.join(" "));
+    const pacResult = await pac(...pacArgs);
+    logger.log("AssignUser Action Result: " + pacResult);
+
+  } catch (error) {
+    logger.error(`failed: ${error instanceof Error ? error.message : error}`);
+    throw error;
+  } finally {
+    const clearAuthResult = await clearAuthentication(pac);
+    logger.log("The Clear Authentication Result: " + clearAuthResult);
+  }
+}

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -24,3 +24,4 @@ export * from "./updateVersionSolution";
 export * from "./onlineVersionSolution";
 export * from "./installApplication";
 export * from "./listApplication";
+export * from "./assignUser";

--- a/test/actions/assignUser.test.ts
+++ b/test/actions/assignUser.test.ts
@@ -1,0 +1,66 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import rewiremock from "../rewiremock";
+import * as sinonChai from "sinon-chai";
+import * as chaiAsPromised from "chai-as-promised";
+import { should, use } from "chai";
+import { restore, stub } from "sinon";
+import { ClientCredentials, RunnerParameters } from "../../src";
+import { AssignUserParameters } from "../../src/actions";
+import { createDefaultMockRunnerParameters, createMockClientCredentials } from "./mock/mockData";
+import { mockHost } from "./mock/mockHost";
+import Sinon = require("sinon");
+should();
+use(sinonChai);
+use(chaiAsPromised);
+
+describe("action: assignUser", () => {
+  let pacStub: Sinon.SinonStub<any[], any>;
+  let authenticateAdminStub: Sinon.SinonStub<any[], any>;
+  let clearAuthenticationStub: Sinon.SinonStub<any[], any>;
+  const host = new mockHost();
+  const mockClientCredentials: ClientCredentials = createMockClientCredentials();
+  let assignUserParameters: AssignUserParameters;
+
+  beforeEach(() => {
+    pacStub = stub();
+    authenticateAdminStub = stub();
+    clearAuthenticationStub = stub();
+    assignUserParameters = createMinMockResetEnvironmentParameters();
+  });
+  afterEach(() => restore());
+
+  async function runActionWithMocks(assignUserParameters: AssignUserParameters): Promise<void> {
+    const runnerParameters: RunnerParameters = createDefaultMockRunnerParameters();
+
+    const mockedActionModule = await rewiremock.around(() => import("../../src/actions/assignUser"),
+      (mock : any) => {
+        mock(() => import("../../src/pac/createPacRunner")).withDefault(() => pacStub);
+        mock(() => import("../../src/pac/auth/authenticate")).with(
+          {
+            authenticateAdmin: authenticateAdminStub,
+            clearAuthentication: clearAuthenticationStub
+          });
+      });
+
+      authenticateAdminStub.returns("Authentication successfully created.");
+      clearAuthenticationStub.returns("Authentication profiles and token cache removed");
+      pacStub.returns(["Adding user to environment..."]);
+      await mockedActionModule.assignUser(assignUserParameters, runnerParameters, host);
+  }
+
+  const createMinMockResetEnvironmentParameters = (): AssignUserParameters => ({
+    credentials: mockClientCredentials,
+    environment: { name: "Environment", required: true },
+    objectId: { name: "ObjectId", required: true },
+    role: { name: "Role", required: true }
+  });
+
+  it("with minimal inputs, calls pac runner with correct arguments", async () => {
+    await runActionWithMocks(assignUserParameters);
+
+    authenticateAdminStub.should.have.been.calledOnceWith(pacStub, mockClientCredentials);
+    pacStub.should.have.been.calledOnceWith("admin", "assign-user", "--environment", host.environment, "--object-id", host.objectId, "--role", host.role);
+    clearAuthenticationStub.should.have.been.calledOnceWith(pacStub);
+  });
+
+});

--- a/test/actions/mock/mockHost.ts
+++ b/test/actions/mock/mockHost.ts
@@ -31,6 +31,8 @@ export class mockHost implements IHostAbstractions {
   purpose = 'Purpose';
   buildVersion = '1';
   teamId = '00000000-0000-0000-0000-000000000001';
+  objectId = '00000000-0000-0000-0000-000000000003';
+  role = '00000000-0000-0000-0000-000000000004';
 
   public getInput(entry: HostParameterEntry): string | undefined {
     if (entry.required) {
@@ -64,6 +66,8 @@ export class mockHost implements IHostAbstractions {
         case 'Purpose': return this.purpose;
         case 'BuildVersion': return this.buildVersion;
         case 'TeamId': return this.teamId;
+        case "ObjectId": return this.objectId;
+        case "Role": return this.role;
         default: return 'true';
       }
     }


### PR DESCRIPTION
Added code for assign-user including test case.

**Command Reference:** 
```
Help:
Assign a user to a target environment.

Commands:
Usage: pac admin assign-user --environment --object-id [--role] [--async]

  --environment               ID or URL of the environment to assign a user to. (alias: -env)
  --object-id                 Object ID of AAD user to be assigned to environment (alias: -u)
  --role                      Guid of role to be applied to user (alias: -r)
  --async                     Optional boolean argument to run pac verbs asynchronously, defaults to false. (alias: -a)
```