### PR TITLE
Add editor config with 2 space tabs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# https://editorconfig.org/
+root = true
+
+[*]
+charset = utf-8
+end_of_line = crlf
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{cs,js,ts}]
+indent_size = 2
+
+[*.{json,md,yaml,yml}]
+indent_size = 2


### PR DESCRIPTION
Added editor config from https://github.com/microsoft/powerplatform-vscode/blob/main/.editorconfig. Updated tab to be 2 spaces instead of 4 to match current style of the [PowerPlatform-CLI-Wrapper](https://github.com/microsoft/powerplatform-cli-wrapper) repo to avoid excessive code churn. 