### PR TITLE
BAP API removes 'notes' fields from backup req/resp

### DIFF
--- a/src/actions/backupEnvironment.ts
+++ b/src/actions/backupEnvironment.ts
@@ -11,7 +11,6 @@ export interface BackupEnvironmentParameters {
   environmentUrl?: HostParameterEntry;
   environmentId?: HostParameterEntry;
   backupLabel: HostParameterEntry;
-  notes: HostParameterEntry;
 }
 
 export async function backupEnvironment(parameters: BackupEnvironmentParameters, runnerParameters: RunnerParameters, host: IHostAbstractions): Promise<void> {
@@ -30,7 +29,6 @@ export async function backupEnvironment(parameters: BackupEnvironmentParameters,
     validator.pushInput(pacArgs, "--url", parameters.environmentUrl);
     validator.pushInput(pacArgs, "--environment-id", parameters.environmentId);
     validator.pushInput(pacArgs, "--label", parameters.backupLabel);
-    validator.pushInput(pacArgs, "--notes", parameters.notes);
 
     logger.log("Calling pac cli inputs: " + pacArgs.join(" "));
     const pacResult = await pac(...pacArgs);

--- a/test/actions/backupEnvironment.test.ts
+++ b/test/actions/backupEnvironment.test.ts
@@ -31,7 +31,6 @@ describe("action: backupEnvironment", () => {
       environmentUrl: { name: "EnvironmentUrl", required: true },
       environmentId: { name: "EnvironmentId", required: true },
       backupLabel: { name: 'BackupLabel', required: true },
-      notes: { name: 'Notes', required: true }
     };
   });
   afterEach(() => restore());
@@ -60,7 +59,7 @@ describe("action: backupEnvironment", () => {
 
     authenticateAdminStub.should.have.been.calledOnceWith(pacStub, mockClientCredentials);
     pacStub.should.have.been.calledOnceWith("admin", "backup", "--environment", host.environment,"--url", host.environmentUrl,
-      "--environment-id", host.environmentId, "--label", host.backupLabel, "--notes", host.notes);
+      "--environment-id", host.environmentId, "--label", host.backupLabel);
     clearAuthenticationStub.should.have.been.calledOnceWith(pacStub);
   });
 });


### PR DESCRIPTION
mitigation for breaking change in BAP API, see AB#5990698