### PR TITLE
make agent a mandatory RunnerParameter to force both CI/CD platforms to set agent

### DIFF
--- a/src/CommandRunner.ts
+++ b/src/CommandRunner.ts
@@ -9,8 +9,8 @@ export function createCommandRunner(
   workingDir: string,
   commandPath: string,
   logger: Logger,
-  options?: SpawnOptionsWithoutStdio,
-  agent?: string
+  agent: string,
+  options?: SpawnOptionsWithoutStdio
 ): CommandRunner {
   return async function run(...args: string[]): Promise<string[]> {
     return new Promise((resolve, reject) => {
@@ -32,12 +32,12 @@ export function createCommandRunner(
       errorLineReader.on('line', logOutputFactory(logger.error));
 
       function logOutputFactory(logFunction: (...args: string[]) => void) {
-        return (line: string) => { 
-          allOutput.push(line); 
-          logFunction(line); 
-        }        
+        return (line: string) => {
+          allOutput.push(line);
+          logFunction(line);
+        }
       }
-      
+
       cp.on("exit", (code: number) => {
         if (code === 0) {
           resolve(allOutput);

--- a/src/GitRunner.ts
+++ b/src/GitRunner.ts
@@ -1,8 +1,8 @@
 import { createCommandRunner } from "./CommandRunner";
 import { Logger } from "./Logger";
 
-export function createGitRunner(workingDir: string, logger: Logger): GitRunner {
-  const runCommand = createCommandRunner(workingDir, "git", logger);
+export function createGitRunner(workingDir: string, logger: Logger, agent: string): GitRunner {
+  const runCommand = createCommandRunner(workingDir, "git", logger, agent);
   return {
     log: async (limit?: number) => {
       const args = ["log"];

--- a/src/Parameters.ts
+++ b/src/Parameters.ts
@@ -7,7 +7,7 @@ export interface LoggerParameters
 
 export interface TelemetryParameters
 {
-  agent?: string;
+  agent: string;
 }
 
 export interface RunnerParameters extends LoggerParameters, TelemetryParameters

--- a/src/pac/createPacRunner.ts
+++ b/src/pac/createPacRunner.ts
@@ -3,7 +3,7 @@ import { resolve } from "path";
 import { CommandRunner, createCommandRunner } from "../CommandRunner";
 import { RunnerParameters } from "../Parameters";
 
-export default function createPacRunner({workingDir, runnersDir, logger, agent}: RunnerParameters): CommandRunner 
+export default function createPacRunner({workingDir, runnersDir, logger, agent}: RunnerParameters): CommandRunner
 {
   return createCommandRunner(
     workingDir,
@@ -11,7 +11,7 @@ export default function createPacRunner({workingDir, runnersDir, logger, agent}:
       ? resolve(runnersDir, "pac", "tools", "pac.exe")
       : resolve(runnersDir, "pac_linux", "tools", "pac"),
     logger,
+    agent,
     undefined,
-    agent
   );
 }

--- a/test/CommandRunner.test.ts
+++ b/test/CommandRunner.test.ts
@@ -27,10 +27,10 @@ describe("CommandRunner", () => {
           "cwd",
           "command",
           stubInterface<Logger>(),
+          "myAgent",
           {
             shell: true,
-          },
-          "myAgent"
+          }
         );
         runCommand();
       },

--- a/test/actions/mock/mockData.ts
+++ b/test/actions/mock/mockData.ts
@@ -15,6 +15,7 @@ export const createDefaultMockRunnerParameters = (): RunnerParameters => ({
   runnersDir: (platform() === "win32") ? 'D:/Test/runners/' : '/Test/runners/',
   workingDir: (platform() === "win32") ? 'D:/Test/working/' : '/Test/working/',
   logger: createMockLogger(),
+  agent: "mocha"
 });
 
 export const createMockLogger = (): Logger => ({


### PR DESCRIPTION
while pp-actions happens to set the agent, pp-build-tools does not, hence our tele processing pipeline cannot associate PP.BT telemetry data

[AB#2753357](https://dev.azure.com/dynamicscrm/1fb98997-2f9e-4734-be8a-9728680447c2/_workitems/edit/2753357)