### PR TITLE
normalize region names from friendly names

### DIFF
--- a/src/actions/createEnvironment.ts
+++ b/src/actions/createEnvironment.ts
@@ -36,7 +36,7 @@ export async function createEnvironment(parameters: CreateEnvironmentParameters,
     validator.pushInput(pacArgs, "--name", parameters.environmentName);
     validator.pushInput(pacArgs, "--type", parameters.environmentType);
     validator.pushInput(pacArgs, "--templates", parameters.templates);
-    validator.pushInput(pacArgs, "--region", parameters.region);
+    validator.pushInput(pacArgs, "--region", parameters.region, normalizeRegion);
     validator.pushInput(pacArgs, "--currency", parameters.currency);
     validator.pushInput(pacArgs, "--language", parameters.language);
     validator.pushInput(pacArgs, "--domain", parameters.domainName);
@@ -72,4 +72,19 @@ export function getEnvironmentDetails(pacResult: string[]): EnvironmentResult {
     environmentId: envId,
     environmentUrl: envUrl
   };
+}
+
+// translate to pac CLI accepted region names:
+// PP.BT PS implementation had the BAP friendly names that pac CLI can't accept
+const regionMap: Record<string, string> = {
+  // pac CLI accepts case-insensitive region names, only transpose different names:
+  "united states": "unitedstates",
+  "united kingdom": "unitedkingdom",
+  "preview (united states)": "unitedstatesfirstrelease",
+  "south america": "southamerica",
+};
+
+function normalizeRegion(taskRegionName: string): string {
+  const cliRegionName = regionMap[taskRegionName.toLowerCase()];
+  return cliRegionName || taskRegionName;
 }

--- a/test/actions/createEnvironment.test.ts
+++ b/test/actions/createEnvironment.test.ts
@@ -18,6 +18,7 @@ describe("action: createEnvironment", () => {
   let authenticateAdminStub: Sinon.SinonStub<any[], any>;
   let clearAuthenticationStub: Sinon.SinonStub<any[], any>;
   const host = new mockHost();
+  const remappedRegionUS = 'unitedstates';
   const mockClientCredentials: ClientCredentials = createMockClientCredentials();
   let createEnvironmentParameters: CreateEnvironmentParameters;
 
@@ -72,7 +73,7 @@ describe("action: createEnvironment", () => {
 
     authenticateAdminStub.should.have.been.calledOnceWith(pacStub, mockClientCredentials);
     pacStub.should.have.been.calledOnceWith("admin", "create", "--name", host.environmentName, "--type", host.environmentType,
-      "--region", host.region, "--currency", host.currency, "--language", host.language, "--domain", host.domainName);
+      "--region", remappedRegionUS, "--currency", host.currency, "--language", host.language, "--domain", host.domainName);
     clearAuthenticationStub.should.have.been.calledOnceWith(pacStub);
   });
 
@@ -82,7 +83,7 @@ describe("action: createEnvironment", () => {
     await runActionWithMocks(createEnvironmentParameters);
 
     pacStub.should.have.been.calledOnceWith("admin", "create", "--name", host.environmentName, "--type", host.environmentType,
-      "--templates", host.templates, "--region", host.region, "--currency", host.currency, "--language", host.language, "--domain", host.domainName);
+      "--templates", host.templates, "--region", remappedRegionUS, "--currency", host.currency, "--language", host.language, "--domain", host.domainName);
   });
 
   it("with required params, calls pac to create teams environemnt", async () => {
@@ -90,9 +91,20 @@ describe("action: createEnvironment", () => {
 
     await runActionWithMocks(createEnvironmentParameters);
 
-    pacStub.should.have.been.calledOnceWith("admin", "create", "--name", host.environmentName, "--type", host.environmentType, 
-      "--region", host.region, "--currency", host.currency, "--language", host.language, "--domain", host.domainName,
+    pacStub.should.have.been.calledOnceWith("admin", "create", "--name", host.environmentName, "--type", host.environmentType,
+      "--region", remappedRegionUS, "--currency", host.currency, "--language", host.language, "--domain", host.domainName,
       "--team-id", host.teamId);
   });
 
+
+  it("with region that does not require mapping", async () => {
+    createEnvironmentParameters.teamId = { name: 'TeamId', required: true };
+
+    host.region = 'Australia';
+    await runActionWithMocks(createEnvironmentParameters);
+
+    pacStub.should.have.been.calledOnceWith("admin", "create", "--name", host.environmentName, "--type", host.environmentType,
+      "--region", 'Australia', "--currency", host.currency, "--language", host.language, "--domain", host.domainName,
+      "--team-id", host.teamId);
+  });
 });


### PR DESCRIPTION
normalize region names from friendly names like 'United States' to what the CLI expects: 'unitedstates'

[AB#2756029](https://dev.azure.com/dynamicscrm/1fb98997-2f9e-4734-be8a-9728680447c2/_workitems/edit/2756029)