### PR TITLE
optionally set --overwrite for 'solution export'

### DIFF
--- a/src/actions/exportSolution.ts
+++ b/src/actions/exportSolution.ts
@@ -25,6 +25,10 @@ export interface ExportSolutionParameters {
   outlookSynchronizationSettings: HostParameterEntry;
   relationshipRoles: HostParameterEntry;
   sales: HostParameterEntry;
+  // TODO: for now optional to avoid a breaking change when consuming this cli-wrapper with 1.16.x pac CLI:
+  // Only the QFE-ed pac CLI 1.15.8+ have the --overwrite parameter; the June refresh (1.17.x ) will also have that
+  // BUG: AB#2761762 to remove later
+  overwrite?: HostParameterEntry;
 }
 
 export async function exportSolution(parameters: ExportSolutionParameters, runnerParameters: RunnerParameters, host: IHostAbstractions): Promise<void> {
@@ -40,6 +44,10 @@ export async function exportSolution(parameters: ExportSolutionParameters, runne
 
     validator.pushInput(pacArgs, "--name", parameters.name);
     validator.pushInput(pacArgs, "--path", parameters.path, (value) => path.resolve(runnerParameters.workingDir, value));
+  // BUG: AB#2761762 to remove this conditional later
+    if (parameters.overwrite && validator.getInput(parameters.overwrite) == 'true') {
+      pacArgs.push("--overwrite");
+    }
     validator.pushInput(pacArgs, "--managed", parameters.managed);
     validator.pushInput(pacArgs, "--async", parameters.async);
     validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTimeInMin);

--- a/test/actions/exportSolution.test.ts
+++ b/test/actions/exportSolution.test.ts
@@ -54,6 +54,7 @@ describe("action: exportSolution", () => {
     environmentUrl: environmentUrl,
     name: { name: "SolutionName", required: true },
     path: { name: "SolutionOutputFile", required: true },
+    overwrite: { name: "Overwrite", required: false },
     managed: { name: 'Managed', required: false },
     async: { name: 'AsyncOperation', required: false },
     maxAsyncWaitTimeInMin: { name: 'MaxAsyncWaitTime', required: false },
@@ -95,6 +96,7 @@ describe("action: exportSolution", () => {
         case "ExportOutlookSynchronizationSettings":
         case "ExportRelationshipRoles":
         case "ExportSales":
+        case 'Overwrite':
           return "true";
         case "MaxAsyncWaitTime":
           return "120"
@@ -103,7 +105,7 @@ describe("action: exportSolution", () => {
     });
     await runActionWithMocks(exportSolutionParameters, host);
 
-    pacStub.should.have.been.calledOnceWith("solution", "export", "--name", host.solutionName, "--path", host.absoluteSolutionPath,
+    pacStub.should.have.been.calledOnceWith("solution", "export", "--name", host.solutionName, "--path", host.absoluteSolutionPath, "--overwrite",
       "--managed", "true", "--async", "true", "--max-async-wait-time", "120", "--include",
       "autonumbering,calendar,customization,emailtracking,externalapplications,general,isvconfig,marketing,outlooksynchronization,relationshiproles,sales");
   });
@@ -119,6 +121,7 @@ describe("action: exportSolution", () => {
         case "ExportExternalApplicationSettings":
         case "ExportMarketingSettings":
         case "ExportRelationshipRoles":
+        case 'Overwrite':
           return "true";
         case "ExportCustomizationSettings":
         case "ExportGeneralSettings":
@@ -133,7 +136,7 @@ describe("action: exportSolution", () => {
     });
     await runActionWithMocks(exportSolutionParameters, host);
 
-    pacStub.should.have.been.calledOnceWith("solution", "export", "--name", host.solutionName, "--path", host.absoluteSolutionPath,
+    pacStub.should.have.been.calledOnceWith("solution", "export", "--name", host.solutionName, "--path", host.absoluteSolutionPath, "--overwrite",
       "--managed", "true", "--async", "true", "--max-async-wait-time", "120", "--include",
       "autonumbering,calendar,emailtracking,externalapplications,marketing,relationshiproles");
   });


### PR DESCRIPTION
for now, cli-wrapper needs to make this an opt-in flag, since only the QFE-ed 1.15.8 pac CLI has this new parameter

[AB#2761762](https://dev.azure.com/dynamicscrm/1fb98997-2f9e-4734-be8a-9728680447c2/_workitems/edit/2761762)