### PR TITLE
publishCustomization: async for now optional

### DIFF
--- a/src/actions/publishSolution.ts
+++ b/src/actions/publishSolution.ts
@@ -8,7 +8,8 @@ import { InputValidator } from "../host/InputValidator";
 export interface PublishSolutionParameters {
   credentials: AuthCredentials;
   environmentUrl: string;
-  async: HostParameterEntry;
+  // TODO AB#2761762 remove optional once past 1.15.x QFE process
+  async?: HostParameterEntry;
 }
 
 export async function publishSolution(parameters: PublishSolutionParameters, runnerParameters: RunnerParameters, host: IHostAbstractions): Promise<void> {
@@ -21,7 +22,11 @@ export async function publishSolution(parameters: PublishSolutionParameters, run
 
     const pacArgs = ["solution", "publish"];
     const validator = new InputValidator(host);
-    validator.pushInput(pacArgs, "--async", parameters.async);
+    // AB#2761762 bring back once 1.15.x QFE is removed
+    // validator.pushInput(pacArgs, "--async", parameters.async);
+    if (parameters.async && validator.getInput(parameters.async) == 'true') {
+      pacArgs.push("--async");
+    }
 
     logger.log("Calling pac cli inputs: " + pacArgs.join(" "));
     const pacResult = await pac(...pacArgs);


### PR DESCRIPTION
temporarily, make the async param optional so that we can build and run against pac CLI 1.15.x and 1.16 (only the latter has the async flag)
[AB#2761762](https://dev.azure.com/dynamicscrm/1fb98997-2f9e-4734-be8a-9728680447c2/_workitems/edit/2761762)