### PR TITLE
pac CLI expects BAP regions/language names, but existing pipelines us…

### DIFF
--- a/src/actions/createEnvironment.ts
+++ b/src/actions/createEnvironment.ts
@@ -1,5 +1,5 @@
 import { HostParameterEntry, IHostAbstractions } from "../host/IHostAbstractions";
-import { InputValidator } from "../host/InputValidator";
+import { InputValidator, normalizeLanguage, normalizeRegion } from "../host/InputValidator";
 import { authenticateAdmin, clearAuthentication } from "../pac/auth/authenticate";
 import createPacRunner from "../pac/createPacRunner";
 import { RunnerParameters } from "../Parameters";
@@ -38,7 +38,7 @@ export async function createEnvironment(parameters: CreateEnvironmentParameters,
     validator.pushInput(pacArgs, "--templates", parameters.templates);
     validator.pushInput(pacArgs, "--region", parameters.region, normalizeRegion);
     validator.pushInput(pacArgs, "--currency", parameters.currency);
-    validator.pushInput(pacArgs, "--language", parameters.language);
+    validator.pushInput(pacArgs, "--language", parameters.language, normalizeLanguage);
     validator.pushInput(pacArgs, "--domain", parameters.domainName);
     validator.pushInput(pacArgs, "--team-id", parameters.teamId);
 
@@ -72,19 +72,4 @@ export function getEnvironmentDetails(pacResult: string[]): EnvironmentResult {
     environmentId: envId,
     environmentUrl: envUrl
   };
-}
-
-// translate to pac CLI accepted region names:
-// PP.BT PS implementation had the BAP friendly names that pac CLI can't accept
-const regionMap: Record<string, string> = {
-  // pac CLI accepts case-insensitive region names, only transpose different names:
-  "united states": "unitedstates",
-  "united kingdom": "unitedkingdom",
-  "preview (united states)": "unitedstatesfirstrelease",
-  "south america": "southamerica",
-};
-
-function normalizeRegion(taskRegionName: string): string {
-  const cliRegionName = regionMap[taskRegionName.toLowerCase()];
-  return cliRegionName || taskRegionName;
 }

--- a/src/actions/resetEnvironment.ts
+++ b/src/actions/resetEnvironment.ts
@@ -1,6 +1,6 @@
 
 import { HostParameterEntry, IHostAbstractions } from "../host/IHostAbstractions";
-import { InputValidator } from "../host/InputValidator";
+import { InputValidator, normalizeLanguage } from "../host/InputValidator";
 import { authenticateAdmin, clearAuthentication } from "../pac/auth/authenticate";
 import createPacRunner from "../pac/createPacRunner";
 import { RunnerParameters } from "../Parameters";
@@ -37,7 +37,7 @@ export async function resetEnvironment(parameters: ResetEnvironmentParameters, r
     validator.pushInput(pacArgs, "--environment", parameters.environment);
     validator.pushInput(pacArgs, "--url", parameters.environmentUrl);
     validator.pushInput(pacArgs, "--environment-id", parameters.environmentId);
-    validator.pushInput(pacArgs, "--language", parameters.language);
+    validator.pushInput(pacArgs, "--language", parameters.language, normalizeLanguage);
     validator.pushInput(pacArgs, "--currency", parameters.currency);
     validator.pushInput(pacArgs, "--purpose", parameters.purpose);
     validator.pushInput(pacArgs, "--templates", parameters.templates);

--- a/src/host/InputValidator.ts
+++ b/src/host/InputValidator.ts
@@ -36,3 +36,30 @@ export class InputValidator {
     }
   }
 }
+
+// translate to pac CLI accepted region names:
+// PP.BT PS implementation had the BAP friendly names that pac CLI can't accept
+const regionMap: Record<string, string> = {
+  // pac CLI accepts case-insensitive region names, only transpose different names:
+  "united states": "unitedstates",
+  "united kingdom": "unitedkingdom",
+  "preview (united states)": "unitedstatesfirstrelease",
+  "south america": "southamerica",
+};
+
+export function normalizeRegion(taskRegionName: string): string {
+  const cliRegionName = regionMap[taskRegionName.toLowerCase()];
+  return cliRegionName || taskRegionName;
+}
+// translate to pac CLI accepted language names:
+// PP.BT PS implementation had the BAP friendly names that pac CLI can't accept
+const languageMap: Record<string, string> = {
+  // pac CLI accepts case-insensitive region names, only transpose different names:
+  // pac CLI accepts languages by either the BAP names, e.g. 'English (United States)' or by langCode, here: 1033
+  "English": "1033",
+};
+
+export function normalizeLanguage(taskLanguageName: string): string {
+  const cliLanguageName = languageMap[taskLanguageName.toLowerCase()];
+  return cliLanguageName || taskLanguageName;
+}


### PR DESCRIPTION
…e e.g. language = 'English', but BAP expects 'English (United States)'