### PR TITLE
Remove unnecessary Auth for offline `pac solution version` command

### DIFF
--- a/src/actions/updateVersionSolution.ts
+++ b/src/actions/updateVersionSolution.ts
@@ -1,12 +1,9 @@
 import { HostParameterEntry, IHostAbstractions, CommonActionParameters } from "../host/IHostAbstractions";
 import { InputValidator } from "../host/InputValidator";
-import { authenticateEnvironment, clearAuthentication } from "../pac/auth/authenticate";
 import createPacRunner from "../pac/createPacRunner";
 import { RunnerParameters } from "../Parameters";
-import { AuthCredentials } from "../pac/auth/authParameters";
 
 export interface UpdateVersionSolutionParameters extends CommonActionParameters {
-  credentials: AuthCredentials;
   environmentUrl: string;
   buildVersion?: HostParameterEntry;
   revisionVersion?: HostParameterEntry;
@@ -20,9 +17,6 @@ export async function updateVersionSolution(parameters: UpdateVersionSolutionPar
   const pac = createPacRunner(runnerParameters);
 
   try {
-    const authenticateResult = await authenticateEnvironment(pac, parameters.credentials, parameters.environmentUrl, logger);
-    logger.log("The Authentication Result: " + authenticateResult);
-
     const pacArgs = ["solution", "version"]
     const validator = new InputValidator(host);
 
@@ -39,8 +33,5 @@ export async function updateVersionSolution(parameters: UpdateVersionSolutionPar
   } catch (error) {
     logger.error(`failed: ${error instanceof Error ? error.message : error}`);
     throw error;
-  } finally {
-    const clearAuthResult = await clearAuthentication(pac);
-    logger.log("The Clear Authentication Result: " + clearAuthResult);
   }
 }

--- a/test/actions/updateVersionSolution.test.ts
+++ b/test/actions/updateVersionSolution.test.ts
@@ -4,8 +4,8 @@ import * as sinonChai from "sinon-chai";
 import * as chaiAsPromised from "chai-as-promised";
 import { should, use } from "chai";
 import { restore, stub } from "sinon";
-import { ClientCredentials, RunnerParameters } from "../../src";
-import { createDefaultMockRunnerParameters, createMockClientCredentials, mockEnvironmentUrl } from "./mock/mockData";
+import { RunnerParameters } from "../../src";
+import { createDefaultMockRunnerParameters, mockEnvironmentUrl } from "./mock/mockData";
 import { UpdateVersionSolutionParameters } from "../../src/actions/updateVersionSolution";
 import Sinon = require("sinon");
 import { mockHost } from "./mock/mockHost";
@@ -18,7 +18,6 @@ describe("action: updateVersion solution", () => {
   let authenticateEnvironmentStub: Sinon.SinonStub<any[],any>;
   let clearAuthenticationStub: Sinon.SinonStub<any[], any>;
   const host = new mockHost();
-  const mockClientCredentials: ClientCredentials = createMockClientCredentials();
   const envUrl: string = mockEnvironmentUrl;
   let updateVersionSolutionParameters: UpdateVersionSolutionParameters;
 
@@ -35,11 +34,6 @@ describe("action: updateVersion solution", () => {
     const mockedActionModule = await rewiremock.around(() => import("../../src/actions/updateVersionSolution"),
       (mock) => {
         mock(() => import("../../src/pac/createPacRunner")).withDefault(() => pacStub);
-        mock(() => import("../../src/pac/auth/authenticate")).with(
-          {
-            authenticateEnvironment: authenticateEnvironmentStub,
-            clearAuthentication: clearAuthenticationStub
-          });
       });
 
     authenticateEnvironmentStub.returns("Authentication successfully created.");
@@ -49,7 +43,6 @@ describe("action: updateVersion solution", () => {
   }
 
   const createUpdateVersionSolutionParameters = (): UpdateVersionSolutionParameters => ({
-    credentials: mockClientCredentials,
     environmentUrl: envUrl,
     buildVersion: { name: 'BuildVersion', required: true },
     strategy: { name: 'Strategy', required: false },
@@ -60,8 +53,6 @@ describe("action: updateVersion solution", () => {
   it("with required params, calls pac runner with correct args", async () => {
     await runActionWithMocks(updateVersionSolutionParameters);
 
-    authenticateEnvironmentStub.should.have.been.calledOnceWith(pacStub, mockClientCredentials, envUrl);
     pacStub.should.have.been.calledOnceWith("solution", "version", "--buildversion", host.buildVersion);
-    clearAuthenticationStub.should.have.been.calledOnceWith(pacStub);
   });
 });


### PR DESCRIPTION
`pac solution version` does not require Auth, as it is manipulating local files with no service communication

The similarly named `pac solution online-version` sets the version in Dataverse and requires auth, but this one does not.