### PR TITLE
Mutually exclusive switches on Solution Import

### DIFF
--- a/src/actions/importSolution.ts
+++ b/src/actions/importSolution.ts
@@ -45,8 +45,6 @@ export async function importSolution(parameters: ImportSolutionParameters, runne
 
     validator.pushInput(pacArgs, "--path", parameters.path, resolveFolder);
     validator.pushInput(pacArgs, "--async", parameters.async);
-    validator.pushInput(pacArgs, "--import-as-holding", parameters.importAsHolding);
-    validator.pushInput(pacArgs, "--stage-and-upgrade", parameters.stageAndUpgrade);
     validator.pushInput(pacArgs, "--force-overwrite", parameters.forceOverwrite);
     validator.pushInput(pacArgs, "--publish-changes", parameters.publishChanges);
     validator.pushInput(pacArgs, "--skip-dependency-check", parameters.skipDependencyCheck);
@@ -54,6 +52,15 @@ export async function importSolution(parameters: ImportSolutionParameters, runne
     validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTimeInMin);
     validator.pushInput(pacArgs, "--activate-plugins", parameters.activatePlugins);
     validator.pushInput(pacArgs, "--skip-lower-version", parameters.skipLowerVersion);
+
+    // --import-as-holding and --stage-and-upgrade are mutually exclusive
+    // Only send these switch arguments to PAC if their value is true
+    if (validator.getInput(parameters.importAsHolding)?.toLowerCase() === "true") {
+      validator.pushInput(pacArgs, "--import-as-holding", parameters.importAsHolding);
+    }
+    if (validator.getInput(parameters.stageAndUpgrade)?.toLowerCase() === "true") {
+      validator.pushInput(pacArgs, "--stage-and-upgrade", parameters.stageAndUpgrade);
+    }
 
     if (validator.getInput(parameters.useDeploymentSettingsFile)?.toLowerCase() === "true") {
       validator.pushInput(pacArgs, "--settings-file", parameters.deploymentSettingsFile);

--- a/test/actions/importSolution.test.ts
+++ b/test/actions/importSolution.test.ts
@@ -122,9 +122,9 @@ describe("action: importSolution", () => {
 
     authenticateEnvironmentStub.should.have.been.calledOnceWith(pacStub, mockClientCredentials, environmentUrl);
     pacStub.should.have.been.calledOnceWith("solution", "import", "--path", host.absoluteSolutionPath,
-      "--async", "true", "--import-as-holding", "true", "--force-overwrite", "true", "--publish-changes", "true",
+      "--async", "true", "--force-overwrite", "true", "--publish-changes", "true",
       "--skip-dependency-check", "true", "--convert-to-managed", "true", "--max-async-wait-time", host.maxAsyncWaitTime,
-      "--activate-plugins", "true", "--skip-lower-version", "false", "--settings-file", host.deploymentSettingsFile);
+      "--activate-plugins", "true", "--skip-lower-version", "false", "--import-as-holding", "true", "--settings-file", host.deploymentSettingsFile);
   });
 
   it("with optional inputs set to default values, calls pac runner stub with correct arguments", async () => {
@@ -146,7 +146,7 @@ describe("action: importSolution", () => {
 
     authenticateEnvironmentStub.should.have.been.calledOnceWith(pacStub, mockClientCredentials, environmentUrl);
     pacStub.should.have.been.calledOnceWith("solution", "import", "--path", host.absoluteSolutionPath,
-      "--async", "true", "--import-as-holding", "false", "--force-overwrite", "true", "--publish-changes", "false",
+      "--async", "true", "--force-overwrite", "true", "--publish-changes", "false",
       "--skip-dependency-check", "true", "--convert-to-managed", "false", "--max-async-wait-time", "180", "--activate-plugins", "true", "--skip-lower-version", "false");
   });
 });


### PR DESCRIPTION
Callers for Solution Import return a default value of `false` for both `--import-as-holding` and `--stage-and-upgrade`.  These two arguments are mutually exclusive, and the PAC side validation logic only cares that they _were specificed on the command line_, not that only one of them can be `true`, thus failing the command even when both are false.

This change only adds those parameters to the command line args when they are `true`