### PR TITLE
Revert "Bump chai-as-promised from 7.1.2 to 8.0.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@typescript-eslint/eslint-plugin": "^5.61.0",
         "@typescript-eslint/parser": "^5.62.0",
         "chai": "^4.4.1",
-        "chai-as-promised": "^8.0.0",
+        "chai-as-promised": "^7.1.2",
         "eslint": "^8.51.0",
         "eslint-plugin-node": "^11.1.0",
         "fancy-log": "^2.0.0",
@@ -2131,24 +2131,15 @@
       }
     },
     "node_modules/chai-as-promised": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-8.0.0.tgz",
-      "integrity": "sha512-sMsGXTrS3FunP/wbqh/KxM8Kj/aLPXQGkNtvE5wPfSToq8wkkvBpTZo1LIiEVmC4BwkKpag+l5h/20lBMk6nUg==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.2.tgz",
+      "integrity": "sha512-aBDHZxRzYnUYuIAIPBH2s511DjlKPzXNlXSGFC8CwmroWQLfrW0LtE1nK3MAwwNhJPa9raEjNCmRoFpG0Hurdw==",
       "dev": true,
       "dependencies": {
-        "check-error": "^2.0.0"
+        "check-error": "^1.0.2"
       },
       "peerDependencies": {
         "chai": ">= 2.1.2 < 6"
-      }
-    },
-    "node_modules/chai-as-promised/node_modules/check-error": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
-      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 16"
       }
     },
     "node_modules/chainsaw": {
@@ -12750,20 +12741,12 @@
       }
     },
     "chai-as-promised": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-8.0.0.tgz",
-      "integrity": "sha512-sMsGXTrS3FunP/wbqh/KxM8Kj/aLPXQGkNtvE5wPfSToq8wkkvBpTZo1LIiEVmC4BwkKpag+l5h/20lBMk6nUg==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.2.tgz",
+      "integrity": "sha512-aBDHZxRzYnUYuIAIPBH2s511DjlKPzXNlXSGFC8CwmroWQLfrW0LtE1nK3MAwwNhJPa9raEjNCmRoFpG0Hurdw==",
       "dev": true,
       "requires": {
-        "check-error": "^2.0.0"
-      },
-      "dependencies": {
-        "check-error": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
-          "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
-          "dev": true
-        }
+        "check-error": "^1.0.2"
       }
     },
     "chainsaw": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@typescript-eslint/eslint-plugin": "^5.61.0",
     "@typescript-eslint/parser": "^5.62.0",
     "chai": "^4.4.1",
-    "chai-as-promised": "^8.0.0",
+    "chai-as-promised": "^7.1.2",
     "eslint": "^8.51.0",
     "eslint-plugin-node": "^11.1.0",
     "fancy-log": "^2.0.0",


### PR DESCRIPTION
Reverts microsoft/powerplatform-cli-wrapper#418

Change breaks the unit tests, in a way that apparently isn't failing the PR build.
Reverting to fix, but will investigate the PR build afterward.