### PR TITLE
Rename paportal to pages

### DIFF
--- a/src/actions/uploadPaportal.ts
+++ b/src/actions/uploadPaportal.ts
@@ -21,7 +21,7 @@ export async function uploadPaportal(parameters: UploadPaportalParameters, runne
     const authenticateResult = await authenticateEnvironment(pac, parameters.credentials, parameters.environmentUrl, logger);
     logger.log("The Authentication Result: " + authenticateResult);
 
-    const pacArgs = ["paportal", "upload"]
+    const pacArgs = ["pages", "upload"]
     const validator = new InputValidator(host);
 
     validator.pushInput(pacArgs, "--path", parameters.path);


### PR DESCRIPTION
As stated on https://learn.microsoft.com/en-us/power-platform/developer/cli/reference/pages#pac-pages-upload, the 'paportal' command was renamed to 'pages'. For now 'paportal' still works, but I don't know for how long it will.