### PR TITLE
Uptake version 1.43.6 of PAC 

### DIFF
--- a/nuget.json
+++ b/nuget.json
@@ -7,12 +7,12 @@
       "packages": [
         {
           "name": "Microsoft.PowerApps.CLI",
-          "version": "1.33.5",
+          "version": "1.43.6",
           "internalName": "pac"
         },
         {
           "name": "Microsoft.PowerApps.CLI.Core.linux-x64",
-          "version": "1.33.5",
+          "version": "1.43.6",
           "internalName": "pac_linux",
           "chmod": "tools/pac"
         }


### PR DESCRIPTION
This pull request updates the `nuget.json` file to upgrade the version of the `Microsoft.PowerApps.CLI` and `Microsoft.PowerApps.CLI.Core.linux-x64` packages.

* Updated `Microsoft.PowerApps.CLI` package version from `1.33.5` to `1.43.6` in `nuget.json`.
* Updated `Microsoft.PowerApps.CLI.Core.linux-x64` package version from `1.33.5` to `1.43.6` in `nuget.json`.