### PR TITLE
fix(ci): publish workflow cannot run release-it@21 on Node 16

### DIFF
--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -23,7 +23,9 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          # release-it@21 (used by `npm run set-version`) declares
+          # engines.node "^22.21.0 || >=24.0.0" -- Node 16 cannot run it.
+          node-version: 24
           registry-url: "https://npm.pkg.github.com"
 
       - name: Setup git tag committer info for set-version
@@ -33,7 +35,6 @@ jobs:
 
       - name: Build
         run: |
-          npm i -g npm@8.19.4
           npm ci
           npm run set-version
           npm run dist


### PR DESCRIPTION
Fixes a latent break in `Publish.yml`. **Correction to my original description: this is not release-blocking** - see "Revised impact" below. I am leaving the correction visible rather than silently editing it away.

## Problem

#506 upgraded `release-it` 17 -> 21 (required to clear three moderate `@octokit` ReDoS advisories). `release-it@21` declares:

```
engines.node: "^22.21.0 || >=24.0.0"
```

`Publish.yml` provisions **Node 16** and runs `npm run set-version`, which is `node node_modules/release-it/bin/release-it ...`. That combination cannot work, so this workflow would fail if it were ever triggered by an `rc*` tag.

## Revised impact (corrected)

I originally wrote that this blocked shipping the #506 security fixes. That was wrong, and I want to be precise about it:

- `.release-it.yaml` contains an `after:release` hook emitting `##vso[task.setvariable ...]`, which is Azure DevOps syntax. The actual publisher is the **`PowerPlatform-DPX-Tools-GitHub-CLI-Wrapper-Official` ADO pipeline**, not this GitHub workflow.
- There is **no `Publish Npm Package` run in the repo's recent run history at all**, yet tag `v0.1.150` exists and points at `5c1085e` (#506).
- The annotated tag was created `2026-08-14T00:45:41Z` by `DPX Tools Team`, with the message:
  ```
  build 0.1.150:
  * fix(security): resolve S360/Component Governance alerts (0 high, 0 moderate) (#506)
  * chore(security): automate weekly dependency security refresh (#507)
  ```

So **v0.1.150 already ships both #506 and #507**, and the ADO pipeline ran `release-it@21` successfully - meaning ADO is on a Node version that satisfies the engines range.

`Publish.yml` is therefore a secondary/dormant path. This PR removes a trap for whoever next pushes an `rc*` tag expecting it to work, rather than unblocking anything today.

## Changes

Publish job only, two lines:

1. `node-version: 16` -> `24`. Chose the `>=24.0.0` branch of the engines range rather than `22`, so there is no dependency on setup-node resolving a 22.x at or above the 22.21.0 floor.
2. Removed `npm i -g npm@8.19.4`. npm 8 does not support Node 24, and the pin is not needed: `package-lock.json` is `lockfileVersion: 3`, which Node 24's bundled npm reads natively.

## Why PullRequest.yml is deliberately left on Node 16

Not an oversight. The test suite runs through `gulp-mocha` -> `ts-node/register`, and Node >= 22.6 native TypeScript stripping conflicts with it (`ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX`). That is exactly the failure I hit locally on Node 24 while working on #506, and why CI (Node 16) was green when local was red.

The publish job is safe to move because **it never runs tests**: `npm run dist` maps to `recompile` alone (`gulpfile.mjs:20` -> `recompile as dist`), unlike `ci` which is `series(recompile, lint, restore, test)`.

## Verification (local, Node 24.14.1)

| Check | Result |
|---|---|
| `npm ci` | exit 0 |
| `npm run dist` | `compile` finished, exit 0 |
| `release-it --version` | `v21.0.1` loads |
| `release-it --increment patch --ci -VV --dry-run` | exit 0 |

The dry run confirms the existing `.release-it.yaml` is still schema-compatible with v21 - every key is honored:

```
! git tag --annotate --message build ... --force v0.0.1
! git push --tags https://github.com/microsoft/powerplatform-cli-wrapper
! echo ##vso[task.setvariable variable=CLI_WRAPPER_VERSION;]0.0.1
```

i.e. `tagName: v${version}`, `tagArgs: [--force]`, `pushRepo`, the `after:release` ADO variable hook, `npm.publish: false` and `github.release: false` all resolve as intended. (The `0.0.0...0.0.1` numbering is an artifact of my shallow clone having no tags; CI checks out with `fetch-depth: 0`.)

All 6 PR checks are green.

## Not addressed here

`npm audit` currently reports 4 high, all one dev-only chain: `nanoid < 3.3.18` -> `postcss` -> `@gulp-sourcemaps/identity-map` -> `gulp-sourcemaps`. The `nanoid` override is already `^3.3.17`, so the caret admits the fix; `3.3.18` is simply not mirrored on `packagefeedproxy.microsoft.io` yet (upstream has tagged it). The weekly job added in #507 will pick it up on the first run after the mirror syncs - no code change needed.
