### PR TITLE
fix(ci): degrade gracefully when Actions may not open PRs

### DIFF
--- a/.github/workflows/dependency-security.yml
+++ b/.github/workflows/dependency-security.yml
@@ -107,6 +107,33 @@ jobs:
           # No --reviewer here: .github/CODEOWNERS already requests a review for every file
           # this PR touches, and passing a team reviewer explicitly can fail depending on the
           # GITHUB_TOKEN's permissions.
-          gh pr create --base main --head "$BRANCH" \
-            --title "chore: weekly dependency security refresh" \
-            --body-file pr-body.md
+          #
+          # Actions cannot open a PR when the org/repo policy "Allow GitHub Actions to create
+          # and approve pull requests" is disabled. By this point the branch is pushed and the
+          # build is green, so the work is not lost. Failing the run would put a red X on the
+          # weekly job every week for a reason nobody can fix from the workflow, which just
+          # trains people to ignore it. Surface an actionable link instead.
+          if ! gh pr create --base main --head "$BRANCH" \
+                --title "chore: weekly dependency security refresh" \
+                --body-file pr-body.md 2> pr-error.log; then
+            cat pr-error.log >&2
+            if grep -q "not permitted to create or approve pull requests" pr-error.log; then
+              echo "::warning::Branch '$BRANCH' was pushed and is green, but Actions is not allowed to open PRs in this repo. Open it manually, or enable Settings > Actions > General > 'Allow GitHub Actions to create and approve pull requests'."
+              {
+                echo "## Dependency refresh is ready, but the PR could not be opened automatically"
+                echo
+                echo "Branch \`$BRANCH\` has been pushed and the build passed."
+                echo
+                echo "**Open the PR:** https://github.com/${GITHUB_REPOSITORY}/compare/main...${BRANCH}?expand=1"
+                echo
+                echo "To let future runs open it themselves, enable **Settings > Actions > General >"
+                echo "\"Allow GitHub Actions to create and approve pull requests\"**."
+                echo
+                echo "---"
+                echo
+                cat pr-body.md
+              } >> "$GITHUB_STEP_SUMMARY"
+            else
+              exit 1
+            fi
+          fi


### PR DESCRIPTION
Ports powerplatform-build-tools#1462. The weekly refresh workflow added here in #507 is the same workflow, so it carries the same latent failure - I found it by actually running the build-tools copy rather than assuming it worked.

## What happened over there

Run: https://github.com/microsoft/powerplatform-build-tools/actions/runs/31760462499

Every meaningful step passed - `npm ci`, `npm update`, `audit-overrides.js`, build and test - and the branch was pushed. Then the final step failed:

```
pull request create failed: GraphQL: GitHub Actions is not permitted to create or approve pull requests (createPullRequest)
```

That is the repo/org policy **Settings > Actions > General > "Allow GitHub Actions to create and approve pull requests"**. It is not a workflow bug, and no token or `permissions:` change avoids it - it applies to `GITHUB_TOKEN`-driven Actions runs.

## The change

Failing the whole run for a policy the workflow cannot satisfy would put a red X on the weekly job **every week**, which reliably trains people to stop looking at it. Silently passing would hide real breakage. So the step distinguishes the two cases:

| Outcome | Behavior |
|---|---|
| The policy error | `::warning::` + job summary with a prefilled compare link and the full PR body, exit **0** |
| Any other error | stderr printed, exit **1** (unchanged) |

The underlying `gh` error is printed in both cases, and the branch is already pushed and green at that point, so the refresh is recoverable in one click from the run summary.

If an admin enables the setting, nothing here needs to change - runs will simply open their own PRs and never reach the fallback.

## Verification

Tested in the build-tools PR with a stubbed `gh` reproducing the exact stderr:

- policy error -> warning emitted, summary written with the compare URL, **exit 0**
- unrelated error -> **exit 1**, fallback not triggered, so genuine failures are not masked

For this repo specifically: `yaml.load` parses the workflow and `bash -n` is clean on the extracted step script.

## Worth noting

The build-tools run was not wasted - its output became powerplatform-build-tools#1461, upgrading **`nanoid` 3.3.17 -> 3.3.18** and clearing **GHSA-2v37-7h3g-55p8** (HIGH). That is the advisory documented on #506 as not-yet-fixable because `3.3.18` was not mirrored on `packagefeedproxy.microsoft.io`. The mirror has since synced.

**This repo still shows the same 4 highs** from that one dev-only chain (`nanoid` -> `postcss` -> `@gulp-sourcemaps/identity-map` -> `gulp-sourcemaps`). The `nanoid` override here is already `^3.3.17`, so once this workflow runs it should pick up `3.3.18` the same way.
